### PR TITLE
Examine http status codes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -187,6 +187,14 @@ func launchJob(appCIToken, apiURL string, data []byte) (*http.Response, error) {
 		return nil, fmt.Errorf("error making HTTP request to gangway api: %v", err)
 	}
 
+	// If gangway returns anything than 200, 201, etc bubble up the error
+	if resp.StatusCode > 299 {
+		if resp.StatusCode == http.StatusForbidden {
+			fmt.Fprintf(os.Stderr, "error: are your credentials correct?\n")
+		}
+		return resp, fmt.Errorf("gangway returned %d: %s", resp.StatusCode, resp.Status)
+	}
+
 	return resp, nil
 }
 


### PR DESCRIPTION
I had the wrong token and it wasn't obvious gangway was returning 403