### PR TITLE
cmd: Fail if Gangway API returns non-OK status

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -186,6 +186,9 @@ func launchJob(appCIToken, apiURL string, data []byte) (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error making HTTP request to gangway api: %v", err)
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response code from gangway api: %q", resp.Status)
+	}
 
 	return resp, nil
 }


### PR DESCRIPTION
This PR helps to identify problems related to the authentication token or the API URL. For instance, it can show `403 Forbidden` code if a wrong token is provided.