### PR TITLE
Add JobURL field to JobRunIdentifier

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ const maxJobs = 20
 type JobRunIdentifier struct {
 	JobName  string
 	JobRunID string
+	JobURL   string
 }
 
 type JobStatus struct {
@@ -139,6 +140,7 @@ var cmd = &cobra.Command{
 			jobRunIdentifier := JobRunIdentifier{
 				JobName:  opts.jobName,
 				JobRunID: jobStatus.BuildID,
+				JobURL:   jobStatus.JobURL,
 			}
 			jobRunIdentifiers = append(jobRunIdentifiers, jobRunIdentifier)
 


### PR DESCRIPTION
   ## Summary
   - The `JobRunIdentifier` struct is [mirrored from ci-tools](https://github.com/openshift/ci-tools/blob/91aeed7425cb
   6738b6e36e7f511787b55c9e5267/pkg/jobrunaggregator/jobrunaggregatorlib/util.go#L43) and its JSON output can be fed
   into ci-tools aggregation commands for further analysis.
   - Previously, `JobRunIdentifier` only carried `JobName` and `JobRunID`, while the job URL was fetched from Prow but
    not included in the serialized output.
   - This change adds a `JobURL` field to `JobRunIdentifier` and populates it from `JobStatus.JobURL`, so the Prow job
    URL is now included in the JSON written by `--jobs-file-path`. This gives downstream ci-tools aggregation commands
    direct access to the job URL without needing to resolve it separately.
